### PR TITLE
パッケージの名称を実態に即したものに改名

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bustling-belt",
+  "name": "hello2026",
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
`bustling-belt`は明らかに現状に即した名称となっておらず、リポジトリ名と同様の`hello2026`に変更