### PR TITLE
`.gitignore`にClaude Code及びCodex関連の設定を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ pnpm-debug.log*
 
 # jetbrains setting folder
 .idea/
+
+# Claude Code
+.claude/
+
+# OpenAI Codex / ChatGPT
+.codex/
+.openai/
+


### PR DESCRIPTION
`.gitignore`ファイル上において、Claude CodeもしくはCodexの個人用設定ファイルを管理しないようにする設定を追記