### PR TITLE
2025のものとの対応を追加

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,8 +1,8 @@
 /form / 302
 
-/posts/1541 /posts/2257
-/posts/1631 /posts/2256
-/posts/1534 /posts/2280
-/posts/1486 /posts/2281
-/posts/1533 /posts/2253
-/posts/1481 /posts/2252
+/posts/1541 /posts/2257 301
+/posts/1631 /posts/2256 301
+/posts/1534 /posts/2280 301
+/posts/1486 /posts/2281 301
+/posts/1533 /posts/2253 301
+/posts/1481 /posts/2252 301


### PR DESCRIPTION
/form はチラシに印刷されてしまったのでこれを使う
来年はl.tsukuba.devなどの方が良さそう

```
/posts/1541 /posts/2257
/posts/1631 /posts/2256
/posts/1534 /posts/2280
/posts/1486 /posts/2281
/posts/1533 /posts/2253
/posts/1481 /posts/2252
```